### PR TITLE
feat: add optional creator_email, updater_email, team_name to Metric Sync API payload

### DIFF
--- a/src/dbt_eppo_sync/cli.py
+++ b/src/dbt_eppo_sync/cli.py
@@ -4,7 +4,8 @@ import click
 import os
 import sys
 import pathlib
-from typing import Optional
+import yaml
+from typing import Optional, Dict, Any
 
 # Import the main sync function and constants/errors
 try:
@@ -62,18 +63,56 @@ except ImportError:
     metavar='TAG'
 )
 @click.option(
+    '--creator-email',
+    help="Email of the user to set as metric creator (sync-level). Omit to clear.",
+    metavar='EMAIL'
+)
+@click.option(
+    '--updater-email',
+    help="Email of the user to set as last updater (sync-level). Omit to clear.",
+    metavar='EMAIL'
+)
+@click.option(
+    '--team-name',
+    help="Name of the team to associate with metrics (sync-level, 1–200 chars). Omit to clear.",
+    metavar='NAME'
+)
+@click.option(
     '--dry-run',
     is_flag=True,
     default=False,
     help="Perform parsing and mapping but do not send data to Eppo API. Prints the payload instead."
 )
 @click.version_option(package_name='dbt-eppo-sync') # Reads version from pyproject.toml if installed
+def _load_eppo_sync_config(dbt_project_dir: pathlib.Path) -> Dict[str, Any]:
+    """Load optional eppo_sync config from dbt_project.yml (key 'eppo_sync' or 'vars.eppo_sync')."""
+    config_path = dbt_project_dir / "dbt_project.yml"
+    if not config_path.is_file():
+        return {}
+    try:
+        with open(config_path, "r") as f:
+            data = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError):
+        return {}
+    # Prefer top-level eppo_sync, then vars.eppo_sync
+    sync_config = data.get("eppo_sync") or data.get("vars", {}).get("eppo_sync")
+    if not isinstance(sync_config, dict):
+        return {}
+    return {
+        k: v for k, v in sync_config.items()
+        if k in ("creator_email", "updater_email", "team_name") and v is not None
+    }
+
+
 def main(
     dbt_project_dir: pathlib.Path,
     manifest_path: pathlib.Path,
     eppo_api_key: Optional[str],
     eppo_base_url: str,
     sync_tag: Optional[str],
+    creator_email: Optional[str],
+    updater_email: Optional[str],
+    team_name: Optional[str],
     dry_run: bool
 ):
     """
@@ -84,8 +123,13 @@ def main(
         click.echo("Error: Eppo API Key is required. Set the EPPO_API_KEY environment variable or use the --eppo-api-key option.", err=True)
         sys.exit(1)
 
+    # Load optional sync config from dbt_project.yml; CLI options override
+    file_config = _load_eppo_sync_config(dbt_project_dir)
+    effective_creator = creator_email if creator_email is not None else file_config.get("creator_email")
+    effective_updater = updater_email if updater_email is not None else file_config.get("updater_email")
+    effective_team = team_name if team_name is not None else file_config.get("team_name")
+
     # Convert Path objects back to strings for run_sync function if needed
-    # (Current run_sync expects strings, adjust if run_sync signature changes)
     project_dir_str = str(dbt_project_dir.resolve())
     manifest_path_str = str(manifest_path.resolve())
 
@@ -95,6 +139,12 @@ def main(
     click.echo(f"  Eppo API URL: {eppo_base_url}")
     if sync_tag:
         click.echo(f"  Sync Tag: {sync_tag}")
+    if effective_creator:
+        click.echo(f"  Creator email: {effective_creator}")
+    if effective_updater:
+        click.echo(f"  Updater email: {effective_updater}")
+    if effective_team:
+        click.echo(f"  Team name: {effective_team}")
     click.echo(f"  Dry Run: {dry_run}")
     click.echo("-" * 20)
 
@@ -106,7 +156,10 @@ def main(
             eppo_api_key=eppo_api_key,
             eppo_base_url=eppo_base_url,
             sync_tag=sync_tag,
-            dry_run=dry_run
+            dry_run=dry_run,
+            creator_email=effective_creator,
+            updater_email=effective_updater,
+            team_name=effective_team,
         )
 
         if success:

--- a/src/dbt_eppo_sync/eppo_metric_schema.json
+++ b/src/dbt_eppo_sync/eppo_metric_schema.json
@@ -9,6 +9,22 @@
             "description": "An optional identifier for the source of metrics. Recommended to be defined in CI/CD and not in yaml files",
             "type": "string"
         },
+        "creator_email": {
+            "description": "Email of the user to set as metric creator (sync-level default). Resolved to company user; omit to clear.",
+            "type": "string",
+            "format": "email"
+        },
+        "updater_email": {
+            "description": "Email of the user to set as last updater (sync-level default). Resolved to company user; omit to clear.",
+            "type": "string",
+            "format": "email"
+        },
+        "team_name": {
+            "description": "Name of the team to associate with metrics (sync-level default, 1–200 chars). Resolved by name within company; omit to clear.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200
+        },
         "fact_sources": {
             "description": "A fact source, corresponds to a fact SQL definition in the Eppo UI",
             "type": "array",
@@ -139,6 +155,22 @@
                     "reference_url": {
                         "description": "URL to use for 'Open in GitHub' in Eppo UI (optional)",
                         "type": "string"
+                    },
+                    "creator_email": {
+                        "description": "Email of the user to set as metric creator (per-metric override). Omit to use sync-level or clear.",
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "updater_email": {
+                        "description": "Email of the user to set as last updater (per-metric override). Omit to use sync-level or clear.",
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "team_name": {
+                        "description": "Name of the team to associate with this metric (per-metric override, 1–200 chars). Omit to use sync-level or clear.",
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 200
                     },
                     "numerator": {
                         "description": "Specify how the numerator of this metric should be aggregated",

--- a/src/dbt_eppo_sync/mapper.py
+++ b/src/dbt_eppo_sync/mapper.py
@@ -221,7 +221,10 @@ def map_dbt_to_eppo_sync_payload(
     dbt_semantic_models: List[DbtSemanticModel],
     sql_map: CompiledSqlMap,
     sync_tag: Optional[str] = None,
-    reference_url_base: Optional[str] = None # e.g., base URL for linking back to git repo
+    reference_url_base: Optional[str] = None,  # e.g., base URL for linking back to git repo
+    creator_email: Optional[str] = None,
+    updater_email: Optional[str] = None,
+    team_name: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Maps parsed dbt artifacts to the Eppo bulk sync API payload structure,
@@ -233,6 +236,9 @@ def map_dbt_to_eppo_sync_payload(
         sql_map: Dictionary mapping model unique_ids to compiled SQL.
         sync_tag: An optional tag for the sync operation.
         reference_url_base: Optional base URL for constructing reference links.
+        creator_email: Optional email for metric creator (sync-level default). Omit to clear.
+        updater_email: Optional email for last updater (sync-level default). Omit to clear.
+        team_name: Optional team name to associate with metrics (sync-level default). Omit to clear.
 
     Returns:
         A dictionary formatted for the Eppo '/api/v1/metrics/sync' endpoint.
@@ -451,6 +457,15 @@ def map_dbt_to_eppo_sync_payload(
                 if denominator_payload: denominator_payload["filters"] = eppo_filters # Apply same filters? Check Eppo logic
 
 
+            # --- Per-metric overrides for creator/updater/team (only include when metric overrides sync-level) ---
+            per_metric_meta = {}
+            if _get_meta_value(metric, 'eppo_creator_email') is not None:
+                per_metric_meta["creator_email"] = _get_meta_value(metric, 'eppo_creator_email')
+            if _get_meta_value(metric, 'eppo_updater_email') is not None:
+                per_metric_meta["updater_email"] = _get_meta_value(metric, 'eppo_updater_email')
+            if _get_meta_value(metric, 'eppo_team_name') is not None:
+                per_metric_meta["team_name"] = _get_meta_value(metric, 'eppo_team_name')
+
             # --- Construct Eppo Metric Object ---
             eppo_metric = {
                 "name": metric.get('label') or metric_name, # Prefer label for display name
@@ -461,6 +476,7 @@ def map_dbt_to_eppo_sync_payload(
                 "metric_display_style": _get_meta_value(metric, 'eppo_display_style'),
                 "minimum_detectable_effect": _get_meta_value(metric, 'eppo_mde'),
                 "reference_url": _get_meta_value(metric, 'eppo_reference_url'),
+                **per_metric_meta,
                 # Required/Optional structures
                 "numerator": numerator_payload,
                 "denominator": denominator_payload,
@@ -494,6 +510,13 @@ def map_dbt_to_eppo_sync_payload(
         "fact_sources": eppo_fact_sources,
         "metrics": eppo_metrics
     }
+    # Sync-level optional fields (only include when provided; omit = clear on API)
+    if creator_email is not None:
+        final_payload["creator_email"] = creator_email
+    if updater_email is not None:
+        final_payload["updater_email"] = updater_email
+    if team_name is not None:
+        final_payload["team_name"] = team_name
 
     print(f"\nFinished mapping. Generated {len(eppo_fact_sources)} fact sources and {len(eppo_metrics)} metrics.")
     return final_payload

--- a/src/dbt_eppo_sync/sync.py
+++ b/src/dbt_eppo_sync/sync.py
@@ -53,7 +53,10 @@ def run_sync(
     eppo_api_key: str,
     eppo_base_url: Optional[str] = None,
     sync_tag: Optional[str] = None,
-    dry_run: bool = False
+    dry_run: bool = False,
+    creator_email: Optional[str] = None,
+    updater_email: Optional[str] = None,
+    team_name: Optional[str] = None,
 ) -> bool:
     """
     Orchestrates the synchronization process from dbt artifacts to Eppo
@@ -74,6 +77,9 @@ def run_sync(
                   Defaults to 'dbt-sync-<timestamp>'.
         dry_run: If True, performs parsing and mapping but does not call the Eppo API.
                  Prints the generated payload instead.
+        creator_email: Optional email for metric creator (sync-level). Omit to leave unchanged/clear.
+        updater_email: Optional email for last updater (sync-level). Omit to leave unchanged/clear.
+        team_name: Optional team name to associate with metrics (sync-level). Omit to leave unchanged/clear.
 
     Returns:
         True if the sync process completed successfully (or dry run was successful).
@@ -119,8 +125,10 @@ def run_sync(
             dbt_metrics=all_metrics,
             dbt_semantic_models=all_semantic_models,
             sql_map=sql_map,
-            sync_tag=effective_sync_tag
-            # TODO: Add reference_url_base if needed/available
+            sync_tag=effective_sync_tag,
+            creator_email=creator_email,
+            updater_email=updater_email,
+            team_name=team_name,
         )
         print(f"Generated payload with {len(eppo_payload.get('fact_sources',[]))} fact sources and {len(eppo_payload.get('metrics',[]))} metrics.")
 

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -108,6 +108,71 @@ def test_map_successful():
     # Note: Percentile-specific fields (percentile value) are not currently supported
 
 
+def test_map_sync_level_creator_updater_team():
+    """Sync-level creator_email, updater_email, team_name appear in payload when provided."""
+    payload = map_dbt_to_eppo_sync_payload(
+        dbt_metrics=SAMPLE_METRICS,
+        dbt_semantic_models=SAMPLE_SEMANTIC_MODELS,
+        sql_map=SAMPLE_SQL_MAP,
+        sync_tag="test-run",
+        creator_email="data-team@company.com",
+        updater_email="ci-bot@company.com",
+        team_name="Analytics",
+    )
+    assert payload["creator_email"] == "data-team@company.com"
+    assert payload["updater_email"] == "ci-bot@company.com"
+    assert payload["team_name"] == "Analytics"
+
+
+def test_map_sync_level_omit_optional_metadata():
+    """When creator_email, updater_email, team_name are omitted they are not in payload (API clears)."""
+    payload = map_dbt_to_eppo_sync_payload(
+        dbt_metrics=SAMPLE_METRICS,
+        dbt_semantic_models=SAMPLE_SEMANTIC_MODELS,
+        sql_map=SAMPLE_SQL_MAP,
+        sync_tag="test-run",
+    )
+    assert "creator_email" not in payload
+    assert "updater_email" not in payload
+    assert "team_name" not in payload
+
+
+def test_map_per_metric_override_creator_team():
+    """Per-metric eppo_creator_email, eppo_team_name in meta override sync-level for that metric only."""
+    metrics_with_override = [
+        {
+            "name": "total_revenue",
+            "label": "Total Revenue",
+            "type": "sum",
+            "measure": {"name": "revenue"},
+            "meta": {"eppo_creator_email": "analyst@company.com", "eppo_team_name": "Growth"},
+        },
+        {
+            "name": "avg_revenue",
+            "label": "Avg Revenue",
+            "type": "average",
+            "measure": {"name": "revenue"},
+        },
+    ]
+    payload = map_dbt_to_eppo_sync_payload(
+        dbt_metrics=metrics_with_override,
+        dbt_semantic_models=SAMPLE_SEMANTIC_MODELS,
+        sql_map=SAMPLE_SQL_MAP,
+        sync_tag="test-run",
+        creator_email="default@company.com",
+        team_name="Analytics",
+    )
+    assert payload["creator_email"] == "default@company.com"
+    assert payload["team_name"] == "Analytics"
+    eppo_metrics = {m["name"]: m for m in payload["metrics"]}
+    # Total Revenue has per-metric override
+    assert eppo_metrics["Total Revenue"].get("creator_email") == "analyst@company.com"
+    assert eppo_metrics["Total Revenue"].get("team_name") == "Growth"
+    # Avg Revenue has no override, so no per-metric fields (uses sync-level)
+    assert "creator_email" not in eppo_metrics["Avg Revenue"]
+    assert "team_name" not in eppo_metrics["Avg Revenue"]
+
+
 def test_map_missing_sql():
     """Test warning when compiled SQL is missing for a linked SM."""
     # The mapper now logs a warning and continues instead of raising

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -76,9 +76,42 @@ def test_run_sync_successful_live(mock_dependencies):
     # Assert
     assert success is True
     mock_dependencies['parse'].assert_called_once_with(dbt_project_dir=PROJECT_DIR, manifest_path=MANIFEST_PATH)
-    mock_dependencies['map'].assert_called_once()
+    call_kw = mock_dependencies['map'].call_args[1]
+    assert call_kw.get('creator_email') is None
+    assert call_kw.get('updater_email') is None
+    assert call_kw.get('team_name') is None
     mock_dependencies['client_init'].assert_called_once()
     mock_dependencies['sync_defs'].assert_called_once()
+
+
+def test_run_sync_passes_creator_updater_team_to_mapper(mock_dependencies):
+    """run_sync passes creator_email, updater_email, team_name to map_dbt_to_eppo_sync_payload."""
+    mock_dependencies['parse'].return_value = (
+        [{'name': 'm1'}],
+        [{'name': 'sm1', '_model_unique_id': 'model.p.sm1'}],
+        {'model.p.sm1': 'SELECT 1'},
+    )
+    mock_dependencies['map'].return_value = {
+        "sync_tag": "test",
+        "fact_sources": [],
+        "metrics": [],
+    }
+    success = sync.run_sync(
+        dbt_project_dir=PROJECT_DIR,
+        manifest_path=MANIFEST_PATH,
+        eppo_api_key=API_KEY,
+        dry_run=True,
+        creator_email="data@company.com",
+        updater_email="ci@company.com",
+        team_name="Analytics",
+    )
+    assert success is True
+    mock_dependencies['map'].assert_called_once()
+    call_kw = mock_dependencies['map'].call_args[1]
+    assert call_kw['creator_email'] == "data@company.com"
+    assert call_kw['updater_email'] == "ci@company.com"
+    assert call_kw['team_name'] == "Analytics"
+
 
 def test_run_sync_successful_dry_run(mock_dependencies):
     """Test a successful run in dry run mode."""


### PR DESCRIPTION
## Summary

Adds support for the new optional Metric Sync API fields: **creator_email**, **updater_email**, and **team_name** at both sync-level and per-metric level. Sync-level values apply as defaults to all metrics; individual metrics can override via dbt `meta` keys.

**Resolves:** [FFESUPPORT-407](https://datadoghq.atlassian.net/browse/FFESUPPORT-407)

**Dependency:** This work depends on the Metric Sync API changes in **Eppo-exp/eppo** — [PR #13697](https://github.com/Eppo-exp/eppo/pull/13697). That PR augments the API to accept these optional body fields and defines semantics (omit = clear, lookup failure = clear, per-metric overrides). This PR updates dbt-eppo-sync to send the new fields when configured.

---

## Changes

### 1. Mapper (`mapper.py`)

- **Sync-level:** `map_dbt_to_eppo_sync_payload()` now accepts optional `creator_email`, `updater_email`, and `team_name`. When provided, they are included in the top-level request body next to `sync_tag`, `fact_sources`, and `metrics`. When omitted, the keys are not sent (API treats omit as clear).
- **Per-metric:** For each metric, the mapper reads from `meta`:
  - `eppo_creator_email` → `creator_email`
  - `eppo_updater_email` → `updater_email`
  - `eppo_team_name` → `team_name`
  Only metrics that define these in `meta` get the corresponding keys on their object; others rely on sync-level defaults on the API side.

### 2. Sync orchestration (`sync.py`)

- `run_sync()` accepts optional `creator_email`, `updater_email`, and `team_name` and passes them through to the mapper.

### 3. CLI (`cli.py`)

- New options: `--creator-email`, `--updater-email`, `--team-name`.
- **Config file:** Optional sync config is read from `dbt_project.yml`:
  - Top-level key `eppo_sync`, or
  - `vars.eppo_sync`
  Supported keys: `creator_email`, `updater_email`, `team_name`. CLI options override config file values when both are set.

### 4. Schema (`eppo_metric_schema.json`)

- Top-level optional properties: `creator_email`, `updater_email`, `team_name` (with descriptions and format/length constraints).
- Under `metrics.items`: same three as optional per-metric properties.

### 5. Tests

- **test_mapper.py:** `test_map_sync_level_creator_updater_team`, `test_map_sync_level_omit_optional_metadata`, `test_map_per_metric_override_creator_team`.
- **test_sync.py:** `test_run_sync_passes_creator_updater_team_to_mapper`, and assertions in `test_run_sync_successful_live` that mapper is called with the new params (as `None` when not provided).

---

## Usage

**CLI (overrides config):**
```bash
dbt-eppo-sync --dbt-project-dir . --manifest-path target/manifest.json \
  --creator-email "data-team@company.com" \
  --updater-email "ci-bot@company.com" \
  --team-name "Analytics"
```

**Config in `dbt_project.yml`:**
```yaml
eppo_sync:
  creator_email: "data-team@company.com"
  updater_email: "ci-bot@company.com"
  team_name: "Analytics"
```

**Per-metric override in dbt metric YAML:**
```yaml
metrics:
  - name: my_metric
    label: My Metric
    type: sum
    measure: { name: revenue }
    meta:
      eppo_creator_email: "analyst@company.com"
      eppo_team_name: "Growth"
```

---

## Checklist

- [x] Sync-level and per-metric fields implemented and only sent when set.
- [x] CLI options and dbt_project.yml config support.
- [x] Schema updated; validation continues to pass.
- [x] Tests added/updated for mapper and run_sync.
